### PR TITLE
Fix some data races

### DIFF
--- a/mimosa/src/imu/manager.cpp
+++ b/mimosa/src/imu/manager.cpp
@@ -350,6 +350,8 @@ void Manager::getInterpolatedMeasurements(
 
 size_t Manager::getNumMeasurementsBetween(const double t1, const double t2)
 {
+  std::lock_guard<std::mutex> lock(buffer_mutex_);
+
   const double t_start = std::min(t1, t2);
   const double t_end = std::max(t1, t2);
 


### PR DESCRIPTION
1. Add buffer_mutex to getNumMeasurementsBetween to guard against this method reading data while the imu thread is writing to buffer.
2. I noticed when adding a new barometer manager that the imu preintegration started crashing.
This was because some random baro measurements would have exact same nanosecond stamp as a given imu measurement because they shard hw clock.
This should now be better handled in [dd1672f](https://github.com/ntnu-arl/mimosa/pull/14/commits/dd1672f45c3b9303aef30fb926edc27b5e25629e)
Removed the two-step mutex acqusition in `setPropagationBaseState` to reduce complexity. This will be catched up by next imu callback anyway? 