### PR TITLE
ros2 humble compatibiity

### DIFF
--- a/mimosa/CMakeLists.txt
+++ b/mimosa/CMakeLists.txt
@@ -155,6 +155,19 @@ function(configure_ros_target TARGET_NAME)
     )
   else()
     ament_target_dependencies(${TARGET_NAME} ${ROS2_DEPENDENCIES})
+    # Prefer ROS PCL conversion headers so their ROS message overloads are visible.
+    target_include_directories(
+      ${TARGET_NAME}
+      SYSTEM BEFORE PRIVATE
+      ${pcl_conversions_INCLUDE_DIRS}
+    )
+    # Expose the ROS distro to C++ for distro-specific API and header differences.
+    if(DEFINED ENV{ROS_DISTRO})
+      string(TOUPPER "$ENV{ROS_DISTRO}" ROS_DISTRO_UPPER)
+      target_compile_definitions(
+        ${TARGET_NAME} PRIVATE MIMOSA_ROS_DISTRO_${ROS_DISTRO_UPPER}=1
+      )
+    endif()
   endif()
 
   target_compile_features(

--- a/mimosa/include/mimosa/lidar/utils.hpp
+++ b/mimosa/include/mimosa/lidar/utils.hpp
@@ -19,7 +19,7 @@
 #include <opencv2/imgproc.hpp>
 
 // cv_bridge
-#if DETECTED_ROS_VERSION == 1
+#if DETECTED_ROS_VERSION == 1 || defined(MIMOSA_ROS_DISTRO_HUMBLE)
 #include <cv_bridge/cv_bridge.h>
 #else
 #include <cv_bridge/cv_bridge.hpp>

--- a/mimosa/src/mimosa_rosbag.cpp
+++ b/mimosa/src/mimosa_rosbag.cpp
@@ -326,7 +326,11 @@ int main(int argc, char ** argv)
       }
 
       auto bag_msg = reader.read_next();
+#if defined(MIMOSA_ROS_DISTRO_HUMBLE)
+      int64_t msg_time_ns = bag_msg->time_stamp;
+#else
       int64_t msg_time_ns = bag_msg->recv_timestamp;
+#endif
 
       if ((msg_time_ns - start_time_ns) < static_cast<int64_t>(s_offset * 1e9)) {
         continue;


### PR DESCRIPTION
Add ROS 2 Humble compatibility by exposing the ROS distro to C++ for header/API differences.
In particular, humble->jazzy updated pcl_conversions include paths, cv_bridge.h and rosbag time_stamp API.
I've added a `MIMOSA_ROS_DISTRO_${ROS_DISTRO}` flag in the CMakeLists.